### PR TITLE
Add support for render props methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # react-parm CHANGELOG
 
+## 2.5.0
+
+* Add support for [render props](https://reactjs.org/docs/render-props.html) instance methods via `createComponent` by setting static `isRenderProps` property to `true` on the method
+* Add [`createRenderProps`](README.md#createrenderprops) method
+* Add passing of `args` for `createRender` method
+
 ## 2.4.0
 
 * Add support for additional render methods via `createComponent` by setting static `isRender` property to `true` on the method

--- a/DEV_ONLY/App.js
+++ b/DEV_ONLY/App.js
@@ -72,9 +72,22 @@ const onClickIncrementCounter = (instance, [event]) => {
   }));
 };
 
-const renderProps = ({foo}) => <div>{foo}</div>;
+const RenderProp = ({children}) => <div>{children({render: 'prop'})}</div>;
 
-renderProps.isRender = true;
+RenderProp.propTypes = {
+  children: PropTypes.func.isRequired
+};
+
+const renderPropMethod = (props, instance) => {
+  console.group('render props');
+  console.log('render props', props);
+  console.log('instance props', instance.props);
+  console.groupEnd('render props');
+
+  return <span>Render prop: {props.render}</span>;
+};
+
+renderPropMethod.isRenderProps = true;
 
 const Generated = (props, instance) => {
   console.log('render instance', instance);
@@ -83,7 +96,7 @@ const Generated = (props, instance) => {
     <div>
       <Span>Props: {JSON.stringify(props)}</Span>
 
-      {instance.renderProps(props)}
+      <RenderProp>{instance.renderPropMethod}</RenderProp>
     </div>
   );
 };
@@ -107,7 +120,7 @@ const GeneratedParm = createComponent(Generated, {
   onConstruct(instance) {
     console.log('constructed', instance);
   },
-  renderProps
+  renderPropMethod
 });
 
 console.log('static value', GeneratedParm.staticFoo);

--- a/src/index.js
+++ b/src/index.js
@@ -79,8 +79,23 @@ export const createMethod = (instance, method, ...extraArgs) =>
  */
 export const createRender = (instance, render) =>
   isClassComponent(instance)
-    ? bindSetState(instance) && (() => render.call(instance, instance.props, instance))
+    ? bindSetState(instance) && ((...args) => render.call(instance, instance.props, instance, args))
     : logInvalidInstanceError('render');
+
+/**
+ * @function createRenderProps
+ *
+ * @description
+ * create a render props method, where the props passed and the instance it is rendered in are passed as props to it
+ *
+ * @param {ReactComponent} instance the instance the method is assigned to
+ * @param {function} renderProps the render props method
+ * @returns {function(Object): ReactElement} the method with the props and instance passed as values
+ */
+export const createRenderProps = (instance, renderProps) =>
+  isClassComponent(instance)
+    ? bindSetState(instance) && ((props, ...restOfArgs) => renderProps.call(instance, props, instance, restOfArgs))
+    : logInvalidInstanceError('render props');
 
 /**
  * @function createValue
@@ -125,7 +140,9 @@ export const createComponent = (render, options) => {
       if (!IGNORED_COMPONENT_KEYS[key]) {
         this[key] =
           typeof options[key] === 'function'
-            ? options[key].isRender ? createRender(this, options[key]) : createMethod(this, options[key])
+            ? options[key].isRender
+              ? createRender(this, options[key])
+              : options[key].isRenderProps ? createRenderProps(this, options[key]) : createMethod(this, options[key])
             : options[key];
       }
     }


### PR DESCRIPTION
They have a different use-case than render methods, so they have a different function signature.

Also, add `args` passed to render method in `createMethod` as additional argument